### PR TITLE
FIX: remove hyphen from link

### DIFF
--- a/javascripts/discourse/initializers/init-nav-bar-additions.js
+++ b/javascripts/discourse/initializers/init-nav-bar-additions.js
@@ -10,12 +10,13 @@ export default {
 
       for (const item of items) {
         const splitSec = item.split(";").map((section) => section.trim());
-        const filter = splitSec[0].replace(/\s+/g, "-").toLowerCase();
+        const filter = splitSec[0];
+        const filterDasherized = splitSec[0].replace(/\s+/g, "-").toLowerCase();
         const title = splitSec[1];
         const location = splitSec[2];
 
         api.addNavigationBarItem({
-          name: `custom_${filter}`,
+          name: `custom_${filterDasherized}`,
           displayName: filter,
           title,
           href: location,


### PR DESCRIPTION
Added a hyphen where there wasn't one previously in b8c4760, this fixes it 