### PR TITLE
FIX: show combined new + unread count when unified new is enabled

### DIFF
--- a/javascripts/discourse/initializers/init-nav-bar-additions.js
+++ b/javascripts/discourse/initializers/init-nav-bar-additions.js
@@ -27,19 +27,28 @@ const COUNTED_FILTERS = {
   "/unread": "unread",
 };
 
-function getCountForFilter(topicTrackingState, filterType) {
+function getCountForFilter(topicTrackingState, filterType, siteSettings) {
   if (!topicTrackingState) {
     return 0;
   }
 
+  const newCount =
+    topicTrackingState.countNew?.() ?? topicTrackingState.newCount ?? 0;
+  const unreadCount =
+    topicTrackingState.countUnread?.() ?? topicTrackingState.unreadCount ?? 0;
+
   if (filterType === "new") {
-    return topicTrackingState.countNew?.() ?? topicTrackingState.newCount ?? 0;
+    // When Discourse's "Unified New" is enabled, the /new route shows both
+    // new and unread topics, so the count should reflect both — matching
+    // the behaviour of Discourse's built-in "New" navigation item.
+    if (siteSettings?.enable_unified_new) {
+      return newCount + unreadCount;
+    }
+    return newCount;
   }
 
   if (filterType === "unread") {
-    return (
-      topicTrackingState.countUnread?.() ?? topicTrackingState.unreadCount ?? 0
-    );
+    return unreadCount;
   }
 
   return 0;
@@ -53,6 +62,7 @@ export default {
       const topicTrackingState = api.container.lookup(
         "service:topic-tracking-state"
       );
+      const siteSettings = api.container.lookup("service:site-settings");
 
       for (const link of settings.nav_links) {
         const { display_name: displayName, url } = link;
@@ -69,9 +79,13 @@ export default {
 
         if (settings.Show_counts && filterType && topicTrackingState) {
           // Use a function for displayName so Discourse re-evaluates it
-          // reactively, picking up count changes from TopicTrackingState
+          // reactively, picking up count changes from TopicTrackingState.
           itemConfig.displayName = () => {
-            const count = getCountForFilter(topicTrackingState, filterType);
+            const count = getCountForFilter(
+              topicTrackingState,
+              filterType,
+              siteSettings
+            );
             return count > 0
               ? `${localizedDisplayName} (${count})`
               : localizedDisplayName;

--- a/javascripts/discourse/initializers/init-nav-bar-additions.js
+++ b/javascripts/discourse/initializers/init-nav-bar-additions.js
@@ -27,7 +27,11 @@ const COUNTED_FILTERS = {
   "/unread": "unread",
 };
 
-function getCountForFilter(topicTrackingState, filterType, siteSettings) {
+function getCountForFilter(
+  topicTrackingState,
+  filterType,
+  { enable_unified_new }
+) {
   if (!topicTrackingState) {
     return 0;
   }
@@ -41,7 +45,7 @@ function getCountForFilter(topicTrackingState, filterType, siteSettings) {
     // When Discourse's "Unified New" is enabled, the /new route shows both
     // new and unread topics, so the count should reflect both — matching
     // the behaviour of Discourse's built-in "New" navigation item.
-    if (siteSettings?.enable_unified_new) {
+    if (enable_unified_new) {
       return newCount + unreadCount;
     }
     return newCount;
@@ -81,11 +85,9 @@ export default {
           // Use a function for displayName so Discourse re-evaluates it
           // reactively, picking up count changes from TopicTrackingState.
           itemConfig.displayName = () => {
-            const count = getCountForFilter(
-              topicTrackingState,
-              filterType,
-              siteSettings
-            );
+            const count = getCountForFilter(topicTrackingState, filterType, {
+              enable_unified_new: siteSettings.enable_unified_new,
+            });
             return count > 0
               ? `${localizedDisplayName} (${count})`
               : localizedDisplayName;

--- a/test/javascripts/acceptance/nav-bar-additions-test.js
+++ b/test/javascripts/acceptance/nav-bar-additions-test.js
@@ -49,4 +49,32 @@ acceptance("Custom Top Navigation Links | Topic Counts", function (needs) {
       .dom(".nav-item_custom_unread-topics a")
       .hasText("Unread Topics (17)", "it shows the custom unread topics count");
   });
+
+  test("shows combined new + unread count for /new when unified new is enabled", async function (assert) {
+    const siteSettings = this.owner.lookup("service:site-settings");
+    siteSettings.enable_unified_new = true;
+
+    const topicTrackingState = this.owner.lookup(
+      "service:topic-tracking-state"
+    );
+    topicTrackingState.countNew = () => 6;
+    topicTrackingState.countUnread = () => 6;
+
+    await visit("/latest");
+
+    assert
+      .dom(".nav-item_custom_new-topics a")
+      .hasText(
+        "New Topics (12)",
+        "it shows combined new + unread count when unified new is enabled"
+      );
+
+    // Unread count should remain unchanged
+    assert
+      .dom(".nav-item_custom_unread-topics a")
+      .hasText(
+        "Unread Topics (6)",
+        "unread count is not affected by unified new"
+      );
+  });
 });


### PR DESCRIPTION
When the `enable_unified_new` site setting is active, Discourse's built-in "New" tab shows `countNew() + countUnread()`. This component was only calling `countNew()` for /new links, producing a lower count than expected.

Now looks up the `site-settings` service and checks `enable_unified_new` to combine both counts for the /new filter, matching the default Discourse behaviour.